### PR TITLE
Fix: Restore missing AuthTriggerService import in useAuth.tsx

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, createContext, useContext } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { User, Session } from '@supabase/supabase-js';
+import AuthTriggerService from '@/services/authTriggerService';
 
 type AuthContextType = {
   user: User | null;


### PR DESCRIPTION
- Fixed login functionality by adding back the AuthTriggerService import
- This import was accidentally removed causing ReferenceError during login
- Login and authentication flow now works properly
- Resolves issue where users couldn't sign in due to undefined AuthTriggerService